### PR TITLE
docs: update Claude config to show both npx and global install options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,39 @@ Add the following to your Claude Desktop configuration file:
 **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 
-#### Basic Configuration:
+#### Option 1: Using npx (Downloads latest version on each Claude startup)
+
+```json
+{
+  "mcpServers": {
+    "sound": {
+      "command": "npx",
+      "args": ["-y", "@blocktopus/mcp-server-alert"]
+    }
+  }
+}
+```
+
+**With Sound Discovery:**
+```json
+{
+  "mcpServers": {
+    "sound": {
+      "command": "npx",
+      "args": ["-y", "@blocktopus/mcp-server-alert", "C:/MyMedia/Sounds"]
+    }
+  }
+}
+```
+
+#### Option 2: Using global install (Faster startup, uses locally installed version)
+
+First install globally:
+```bash
+npm install -g @blocktopus/mcp-server-alert
+```
+
+Then use this configuration:
 ```json
 {
   "mcpServers": {
@@ -53,7 +85,7 @@ Add the following to your Claude Desktop configuration file:
 }
 ```
 
-#### With Sound Discovery (specify your sounds directory):
+**With Sound Discovery:**
 ```json
 {
   "mcpServers": {

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Add the following to your Claude Desktop configuration file:
 {
   "mcpServers": {
     "sound": {
-      "command": "npx",
-      "args": ["-y", "@blocktopus/mcp-server-alert"]
+      "command": "node",
+      "args": ["/usr/local/lib/node_modules/@blocktopus/mcp-server-alert/dist/index.js"]
     }
   }
 }
@@ -58,12 +58,17 @@ Add the following to your Claude Desktop configuration file:
 {
   "mcpServers": {
     "sound": {
-      "command": "npx",
-      "args": ["-y", "@blocktopus/mcp-server-alert", "C:/MyMedia/Sounds"]
+      "command": "node",
+      "args": ["/usr/local/lib/node_modules/@blocktopus/mcp-server-alert/dist/index.js", "C:/MyMedia/Sounds"]
     }
   }
 }
 ```
+
+**Note:** The path to the globally installed module may vary depending on your system:
+- **macOS/Linux**: `/usr/local/lib/node_modules/@blocktopus/mcp-server-alert/dist/index.js`
+- **Windows**: `%APPDATA%\npm\node_modules\@blocktopus\mcp-server-alert\dist\index.js`
+- You can find your global node_modules path by running: `npm root -g`
 
 Replace `C:/MyMedia/Sounds` with the path to your directory containing WAV files. The server will automatically discover all WAV files in that directory and make them available by their filename (without extension).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blocktopus/mcp-server-alert",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "MCP server for generating alerts, sounds, and audio notifications",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

This PR updates the README documentation to clarify the two options for configuring Claude Desktop:

1. **Option 1: Using npx** - Downloads latest version on each Claude startup
2. **Option 2: Using global install** - Faster startup, uses locally installed version

## Changes

- Restructured Claude Desktop configuration section to present both options clearly
- Added explanations of the differences between npx and global install approaches
- Included platform-specific paths for global installations
- Bumped version to 1.1.3

## Why this change?

Users were confused about whether to use `npx` or `node` in their Claude configuration. This update makes it clear that both options are valid with different trade-offs:
- `npx`: Always latest version, but slower startup
- `node` with global install: Faster startup, but requires manual updates

## Commits

- 921d84a: docs: update Claude config to use node instead of npx
- f1548a0: chore: bump version to 1.1.3
- 253dfb2: docs: clarify npx vs global install options in Claude config