### PR TITLE
docs: fix global install to use bin executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ Then use this configuration:
 {
   "mcpServers": {
     "sound": {
-      "command": "node",
-      "args": ["/usr/local/lib/node_modules/@blocktopus/mcp-server-alert/dist/index.js"]
+      "command": "mcp-server-alert"
     }
   }
 }
@@ -90,17 +89,16 @@ Then use this configuration:
 {
   "mcpServers": {
     "sound": {
-      "command": "node",
-      "args": ["/usr/local/lib/node_modules/@blocktopus/mcp-server-alert/dist/index.js", "C:/MyMedia/Sounds"]
+      "command": "mcp-server-alert",
+      "args": ["C:/MyMedia/Sounds"]
     }
   }
 }
 ```
 
-**Note:** The path to the globally installed module may vary depending on your system:
-- **macOS/Linux**: `/usr/local/lib/node_modules/@blocktopus/mcp-server-alert/dist/index.js`
-- **Windows**: `%APPDATA%\npm\node_modules\@blocktopus\mcp-server-alert\dist\index.js`
-- You can find your global node_modules path by running: `npm root -g`
+**Note:** When installed globally, the `mcp-server-alert` command is available in your PATH. If you encounter issues, you can use the full path to the executable:
+- **macOS/Linux**: `/usr/local/bin/mcp-server-alert`
+- **Windows**: `%APPDATA%\npm\mcp-server-alert.cmd`
 
 Replace `C:/MyMedia/Sounds` with the path to your directory containing WAV files. The server will automatically discover all WAV files in that directory and make them available by their filename (without extension).
 


### PR DESCRIPTION
## Summary

This PR fixes the global install configuration in the README to use the proper bin executable instead of calling node directly.

## Why this change?

The package.json has a `bin` entry that creates an executable called `mcp-server-alert` when installed globally. This is the standard and proper way to run CLI tools, rather than calling `node` with the full path to the script.

## Changes

- Updated Option 2 (global install) to use `mcp-server-alert` command directly
- Simplified the configuration from using full paths to just the command name
- Updated the note to reference the executable paths instead of node_modules paths

## Before:
```json
{
  "command": "node",
  "args": ["/usr/local/lib/node_modules/@blocktopus/mcp-server-alert/dist/index.js"]
}
```

## After:
```json
{
  "command": "mcp-server-alert"
}
```

This is cleaner, follows npm CLI best practices, and is less error-prone for users.